### PR TITLE
Added proper version handling and tests

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,9 +11,18 @@ class serf::install{
     }->Exec['unzip_serf']
   }
 
+  case $::osfamily {
+    'Debian': {
+      $install_url = "https://dl.bintray.com/mitchellh/serf/${::serf::version}_linux_${::architecture}.zip"
+    }
+    default: {
+      fail "Operating system ${::operatingsystem} is not supported yet."
+    }
+  }
+
   exec{
     'download_serf':
-      command => "wget ${::serf::install_url} -c -O /tmp/serf_${::serf::version}.zip";
+      command => "wget ${install_url} -c -O /tmp/serf_${::serf::version}.zip";
     'unzip_serf':
       command =>  "unzip -o /tmp/serf_${::serf::version}.zip -d /tmp/serf_${::serf::version}/";
     'install_serf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class serf::params{
-  $version          = '0.2.1'
+  $version          = '0.3.0'
   $protocol_version = 1
   $bind             = $::ipaddress
   $config_dir       = '/etc/serf'
@@ -22,16 +22,6 @@ class serf::params{
     '10.6.20.184',
     '10.5.2.101'
   ]
-
-  case $::osfamily {
-    'Debian': {
-      $install_url    = "https://dl.bintray.com/mitchellh/serf/${version}_linux_${::architecture}.zip"
-    }
-    default: {
-      fail "Operating system ${::operatingsystem} is not supported yet."
-    }
-  }
-
 
   $service_name = 'serf'
   $service_ensure = true

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -6,4 +6,17 @@ describe 'serf::install' do
     it { should contain_exec('unzip_serf') }
     it { should contain_exec('install_serf') }
   end
+  context 'When specifying a version to use' do
+    let(:pre_condition) { 'class { "serf": version => "test_version" }' }
+
+    it { should contain_exec('download_serf').\
+      with_command('wget https://dl.bintray.com/mitchellh/serf/test_version_linux_.zip -c -O /tmp/serf_test_version.zip')
+    }
+    it { should contain_exec('unzip_serf').\
+      with_command('unzip -o /tmp/serf_test_version.zip -d /tmp/serf_test_version/')
+    }
+    it { should contain_exec('install_serf').\
+      with_command('mv /tmp/serf_test_version/serf /usr/local/bin//serf && rm -rf /tmp/serf_test_version*}')
+    }
+  end
 end


### PR DESCRIPTION
The install url has to exist outside of params, because the version number can be overridden. 
(causes puppet to run wget https://dl.bintray.com/mitchellh/serf/0.2.1_linux_i386.zip -c -O /tmp/serf_0.3.0.zip, when version => 0.3.0 is specified)

This moves that logic into the install class where the $::serf::version param is really set, and adds tests for it. 

This also bumps the default version to 0.3.0, which is the current latest.
