### PR TITLE
Improve Vagrantfile, add advertise parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,9 @@ Optional Role for specific node
 #####`rpc_addr`
 The address that Serf will bind to for the agent's internal RPC server, defaults to: ```"${::ipaddress}:7373"```
 
+#####`advertise`
+The address that Serf will provide to other nodes to reach it; defaults to ```${::ipaddress}`.
+
 Eg:
 ```
 $::ipaddress='10.5.2.xxx'
@@ -100,6 +103,22 @@ This module has been tested on:
 * Ubuntu 12.04
 
 Testing on other platforms has been light and cannot be guaranteed.
+
+## Vagrant example
+
+1. Install [Vagrant](http://vagrantup.com) and [VirtualBox](http://virtualbox.org)
+2. Clone this repository: `git clone https://github.com/danieldreier/serf-demo.git`
+3. `cd serf-demo` then run `vagrant up node0` and wait for the first node to start
+4. `vagrant ssh -c 'serf monitor' node0` to monitor the communication the first node sees
+5. in another terminal window, run `vagrant up` and watch members join the cluster
+6. `vagrant ssh node1` then run `serf event foo bar` will trigger an event titled "foo" with a payload "bar"
+7. On node1, run `serf members` to get a list of serf cluster members
+8. `exit` out to your regular command line, run `vagrant halt node2`, then repeat step 7 to see node2's status change to 'failed'.
+
+When you're done, run `vagrant halt` to shut them down, or `vagrant destroy` to remove the VMs entirely.
+
+You can modify the number of nodes created by editing `INSTANCES=5` in the Vagrantfile to some other value, then running `vagrant up` again to bring up the new nodes. If you add other services to the nodes, you'll probably need to increase `MEMORY=128` to `MEMORY=256` or greater.
+
 
 ### Authors
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ SUBNET="192.168.2"
 
 Vagrant.configure("2") do |config|
   config.vm.synced_folder "./", "/etc/puppet/modules/serf"
+  config.vm.synced_folder ".", "/vagrant", :mount_options => ["dmode=777","fmode=777"]
   config.vm.provision :puppet, :options => ["--pluginsync"],
                       :facter           => { "first_node_ip" => "#{SUBNET}.10" } do |puppet|
     puppet.manifests_path = "example"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,20 +1,45 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Shamelessly copied from https://github.com/ripienaar/mcollective-vagrant/blob/master/Vagrantfile
+# Inspired by discussion at https://github.com/hashicorp/serf/issues/127
+
+# create this many nodes
+INSTANCES=5
+
+# Nodes will be called node1.example.net, node2.example.net, etc.
+DOMAIN="example.net"
+
+# these nodes do not need a lot of RAM - 128 is barely enough
+# increase it if you want to run anything else on these boxes
+MEMORY=128
+
+# the instances is a hostonly network, this will
+# be the prefix to the subnet they use
+SUBNET="192.168.2"
+
 Vagrant.configure("2") do |config|
-
-  config.vm.box = "ubuntu-1204"
-  config.vm.network :private_network, ip: "192.168.33.10"
-  
+  config.vm.synced_folder "./", "/etc/puppet/modules/serf"
+  config.vm.provision :puppet, :options => ["--pluginsync"],
+                      :facter           => { "first_node_ip" => "#{SUBNET}.10" } do |puppet|
+    puppet.manifests_path = "example"
+  end
+  if defined? VagrantPlugins::Cachier
+    config.cache.auto_detect = true
+  end
+  if defined?(VagrantPlugins::ProviderVirtualBox::Action::CheckGuestAdditions)
+    config.vbguest.auto_update = false
+  end
+  config.vm.box_url = 'http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box'
+  config.vm.box = 'ubuntu-server-12042-x64-vbox4210'
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
-  end
-  
-  config.vm.provision :puppet do |puppet|
-    puppet.module_path = "../"
-    puppet.manifests_path = "tests"
-    puppet.manifest_file  = "init.pp"
-    puppet.options = "--verbose --debug"
+    vb.customize ["modifyvm", :id, "--memory", MEMORY]
   end
 
+  INSTANCES.times do |i|
+    config.vm.define "node#{i}".to_sym do |vmconfig|
+      vmconfig.vm.network :private_network, ip: "#{SUBNET}.%d" % (10 + i)
+      vmconfig.vm.host_name = "node%d.#{DOMAIN}" % i
+    end
+  end
 end

--- a/example/default.pp
+++ b/example/default.pp
@@ -1,0 +1,12 @@
+node default {
+  class { 'serf':
+    # Note that this is using a hacked version of the serf module to allow
+    # setting the "advertise" parameter. Submitted a pull request.
+    version       => '0.4.1',
+    bind          => $::ipaddress_eth1,
+    advertise     => $::ipaddress_eth1,
+    join          => [ $::first_node_ip ],
+    event_handler => ['/vagrant/example/handler.sh'],
+    rpc_addr      => '0.0.0.0:7373',
+  }
+}

--- a/example/handler.sh
+++ b/example/handler.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copied from http://www.serfdom.io/intro/getting-started/event-handlers.html
+
+echo
+echo "New event: ${SERF_EVENT}. Data follows..."
+while read line; do
+    printf "${line}\n"
+done

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 class serf (
   $version        = $::serf::params::version,
   $bind           = $::serf::params::bind,
+  $advertise      = $::serf::params::advertise,
   $config_file    = $::serf::params::config_file,
   $config_dir     = $::serf::params::config_dir,
   $encrypt        = $::serf::params::encrypt,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,8 +33,8 @@ class serf::install{
     package { $::serf::package_name:
       ensure => $::serf::package_ensure
     }
- } else {
-   fail("The provided install method ${::serf::install_method} is invalid")
- }
+  } else {
+    fail("The provided install method ${::serf::install_method} is invalid")
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class serf::params{
   $version          = '0.3.0'
   $protocol_version = 1
   $bind             = $::ipaddress
+  $advertise        = $::ipaddress
   $config_dir       = '/etc/serf'
   $config_file      = "${config_dir}/serf.conf"
   $log_dir          = '/var/log/serf'

--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -3,6 +3,7 @@ config_file= {}
 config_file['role'] = @role if @role
 config_file['node_name'] = @node if @node
 config_file['bind_addr'] = @bind if @bind
+config_file['advertise'] = @advertise if @advertise
 config_file['encrypt_key'] = @encrypt_key if @encrypt_key
 config_file['log_level'] = @log_level if @log_level
 config_file['protocol'] = @protocol_version.to_i if @protocol_version


### PR DESCRIPTION
Here's my first crack at a more full-featured puppet-serf demo using Vagrant.

Note that this depends upon my PR that adds the advertise parameter. Without advertise, the nodes would try to advertise identical NAT'd addresses and can't reach each other. Since this can't be used without that PR, this includes the changes from that PR, which I'll be closing.
